### PR TITLE
fix: catch NoSectionError for missing [api] section in get_config()

### DIFF
--- a/chutes/config.py
+++ b/chutes/config.py
@@ -71,7 +71,10 @@ def get_config() -> Config:
                         f"Please ensure you have an [auth] section defined in {CONFIG_PATH} with 'hotkey_seed', 'hotkey_name', and 'hotkey_ss58address' values"
                     )
 
-        api_base_url = raw_config.get("api", "base_url")
+        try:
+            api_base_url = raw_config.get("api", "base_url")
+        except NoSectionError:
+            api_base_url = None
         if not api_base_url:
             api_base_url = os.getenv("CHUTES_API_URL", "https://api.chutes.ai")
         generic_config = GenericConfig(api_base_url=api_base_url)


### PR DESCRIPTION
# PR-1: Fix Missing `NoSectionError` Handling for `[api]` Section in `config.py`

## Title
`fix: catch NoSectionError for missing [api] section in get_config()`

## Description

### What
The `get_config()` function handles a missing `[auth]` section gracefully via a `try/except NoSectionError` block, but the subsequent `raw_config.get("api", "base_url")` call is **not wrapped** in any error handling.

If a user has a `config.ini` that contains an `[auth]` section but is missing the `[api]` section (which is optional since the URL can come from `CHUTES_API_URL`), they get an unhandled `configparser.NoSectionError` traceback instead of a helpful message.

### Why
- Consistent error handling: `[auth]` is already handled gracefully
- Users with partially-migrated or manually-written config files hit a confusing Python traceback
- The fix mirrors the existing pattern exactly — minimal change, maximum impact
- The `[api]` section is optional by design (env var fallback exists), so the correct fix is to fall back silently rather than raise

### Behavior Change
- **Before:** `configparser.NoSectionError: No section: 'api'` traceback if `[api]` section missing
- **After:** Falls back to `CHUTES_API_URL` env var or `https://api.chutes.ai` default — consistent with `get_generic_config()`

## Files Changed
- `chutes/chutes/config.py`

## Diff

```diff
--- a/chutes/chutes/config.py
+++ b/chutes/chutes/config.py
@@ -57,8 +57,13 @@ def get_config() -> Config:
             except NoSectionError:
                 if not ALLOW_MISSING:
                     raise AuthenticationRequired(
                         f"Please ensure you have an [auth] section defined in {CONFIG_PATH} with 'hotkey_seed', 'hotkey_name', and 'hotkey_ss58address' values"
                     )

-        api_base_url = raw_config.get("api", "base_url")
-        if not api_base_url:
-            api_base_url = os.getenv("CHUTES_API_URL", "https://api.chutes.ai")
+        try:
+            api_base_url = raw_config.get("api", "base_url")
+        except NoSectionError:
+            api_base_url = None
+        if not api_base_url:
+            api_base_url = os.getenv("CHUTES_API_URL", "https://api.chutes.ai")
         generic_config = GenericConfig(api_base_url=api_base_url)
```

### Before
```python
api_base_url = raw_config.get("api", "base_url")
if not api_base_url:
    api_base_url = os.getenv("CHUTES_API_URL", "https://api.chutes.ai")
```

### After
```python
try:
    api_base_url = raw_config.get("api", "base_url")
except NoSectionError:
    api_base_url = None
if not api_base_url:
    api_base_url = os.getenv("CHUTES_API_URL", "https://api.chutes.ai")
```

## Commit Message
```
fix: catch NoSectionError for missing [api] section in get_config()

The [auth] section NoSectionError was already handled, but the [api]
section read was unprotected. If [api] is absent, fall back to
CHUTES_API_URL env var or the default https://api.chutes.ai.

Matches the existing ALLOW_MISSING pattern and mirrors get_generic_config().
```

---

*Contributed by T68Bot from Project Nobi (projectnobi.ai)*