### PR TITLE
build: migrate from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["setuptools>=75", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chutes"
+dynamic = ["version"]
+description = "Chutes development kit and CLI."
+readme = {file = "README.md", content-type = "text/markdown"}
+license = {text = "MIT"}
+authors = [
+    {name = "Jon Durbin"},
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.10",
+]
+requires-python = ">=3.10"
+dependencies = [
+    "aiohttp[speedups]>=3.10,<4",
+    "backoff>=2.2,<3",
+    "requests>=2.32",
+    "loguru>=0.7.2",
+    "fastapi>=0.110",
+    "uvicorn>=0.32.0,<0.39",
+    "hypercorn[h2]>=0.16,<0.18",
+    "pydantic>=2.9,<3",
+    "orjson>=3.10",
+    "setuptools>=0.75",
+    "substrate-interface>=1.7.11",
+    "rich>=13.0.0",
+    "typer>=0.12.5",
+    "graval>=0.2.6",
+    "prometheus-client>=0.21.0",
+    "cryptography",
+    "psutil",
+    "pyjwt>=2.10.1",
+    "netifaces",
+    "pyudev",
+    "aiofiles>=23",
+    "semver",
+    "huggingface_hub",
+    "hf_transfer",
+    "setproctitle",
+    "cllmv==0.1.3",
+]
+
+[project.optional-dependencies]
+dev = ["black", "flake8", "wheel", "pytest"]
+
+[project.urls]
+Homepage = "https://github.com/chutesai/chutes"
+
+[project.scripts]
+chutes = "chutes.cli:app"
+
+[tool.setuptools.dynamic]
+version = {attr = "chutes._version.version"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools.package-data]
+chutes = ["*.so", "cfsv", "cfsv_v2", "cfsv_v3", "cfsv_v4"]
+"chutes.envdump" = ["*.so"]


### PR DESCRIPTION
Replaces closed #66 (which was based on an older commit and inadvertently reverted fixes from #67 and `959252d`).

This is a clean, rebased PR with **only** `pyproject.toml` — no other file changes.

## Changes

**`pyproject.toml`** (new file)
- Dynamic version from `chutes._version.version` (matches `setup.py` behavior)
- All 26 dependencies match `setup.py` exactly
- Standard `setuptools.build_meta` backend
- `setup.py` left in place for backward compatibility

Note in `setup.py`:
```python
# NOTE: Should replace with a pyproject.toml
```

This PR does exactly that.

---
*T68Bot — [Project Nobi](https://projectnobi.ai)*